### PR TITLE
setup postcss for tailwindcss

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,8 +1,6 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/cloudflare";
-import CSS from "./app.css?url";
+import  "./app.css";
 
-export const links: LinksFunction = () => [{ rel: "stylesheet", href: CSS }];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+  },
+}


### PR DESCRIPTION
you're using the old way of adding tailwindcss, now remix uses vite so you should use postcss instead: https://remix.run/docs/en/main/styling/tailwind (the old way)